### PR TITLE
Fix version pattern matching in validate-version-bump.sh

### DIFF
--- a/scripts/validate-version-bump.sh
+++ b/scripts/validate-version-bump.sh
@@ -12,8 +12,8 @@ fi
 
 echo -e "Python files modified: $PY_FILES_CHANGED"
 
-PR_VERSION=$(grep -E '^version = ' pyproject.toml | head -1 | cut -d'"' -f2)
-MASTER_VERSION=$(git show origin/master:pyproject.toml | grep -E '^version = ' | head -1 | cut -d'"' -f2)
+PR_VERSION=$(grep -E '^version=' pyproject.toml | head -1 | cut -d'"' -f2)
+MASTER_VERSION=$(git show origin/master:pyproject.toml | grep -E '^version=' | head -1 | cut -d'"' -f2)
 
 echo -e "Master version: $MASTER_VERSION"
 echo -e "PR version: $PR_VERSION"


### PR DESCRIPTION
The grep pattern was looking for 'version = ' with spaces, but pyproject.toml uses 'version=' without spaces.